### PR TITLE
Update CI to use branches instead of tags for versioning

### DIFF
--- a/.github/workflows/kdrs_multi_version_build_deploy.yml
+++ b/.github/workflows/kdrs_multi_version_build_deploy.yml
@@ -6,7 +6,6 @@ on:
 permissions:
   contents: write
 env:
-  kdrsInnsynDocVersionPath: /
   baseurl: /kdrs-search-and-view-docs/
   latest_branch: x.y.z
 jobs:
@@ -23,14 +22,37 @@ jobs:
           # get all branches, filter matching origin/x.y.z where xyz are integers, remove origin, sort by version, only get last which is most recent, remove space
           echo latest_branch=$(git branch -r | grep -E 'origin/([0-9]+)\.([0-9]+)\.([0-9]+)$' | sed 's|origin/||' | sort -V | tail -n1 | tr -d '[:space:]') >> $GITHUB_ENV
 
-      # - name: Update kdrsInnsynDocVersionPath for non-main branches
-      #   if: ${{ github.ref_type == 'branch' && github.ref_name != 'master'}}
-      #   run: echo kdrsInnsynDocVersionPath=/preview >> $GITHUB_ENV
+      # ---------------------------------------------------------
+      # BUILD AND DEPLOY TO ROOT. This part only runs if the branch pushed to is the latest version.  
+      # ---------------------------------------------------------
+      - name: Build with Jekyll
+        if: ${{ env.latest_branch == github.ref_name }} 
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: _site
 
-      - name: Set baseurl # To make versions have hyperlinks relative to their directories, overwrite baseurl with version
+      - name: Upload artifact
+        if: ${{ env.latest_branch == github.ref_name }} 
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to root if this is the most recent version
+        if: ${{ env.latest_branch == github.ref_name }} 
+        uses: JamesIves/github-pages-deploy-action@v4.3.1
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: _site # The folder the action should deploy.
+          target-folder: /
+          clean: true # Automatically remove deleted files from the deploy branch
+          clean-exclude: |
+            version/*
+      # ---------------------------------------------------------    
+      # BUILD AND DEPLOY TO /version/x.y.z. This part always runs.
+      # ---------------------------------------------------------
+      - name: Set baseurl # To make versions have hyperlinks relative to their directories, overwrite jekyll baseurl with (baseurl)/version/x.y.z
         run: |
           echo '' >> _config.yml
-          echo baseurl: $(echo '${{env.baseurl}}' | cut -d / -f 1,2)${{env.kdrsInnsynDocVersionPath}} >> _config.yml
+          echo baseurl: $(echo '${{env.baseurl}}' | cut -d / -f 1,2)/version/${{github.ref_name}} >> _config.yml
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
@@ -50,17 +72,8 @@ jobs:
           clean: true # Automatically remove deleted files from the deploy branch
           clean-exclude: |
             !/version/${{github.ref_name}}
-      
-      - name: Deploy to root if this is the most recent version
-        if: ${{ env.latest_branch == github.ref_name }} 
-        uses: JamesIves/github-pages-deploy-action@v4.3.1
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: _site # The folder the action should deploy.
-          target-folder: /
-          clean: true # Automatically remove deleted files from the deploy branch
-          clean-exclude: |
-            version/*
+
+
             
       
     

--- a/.github/workflows/kdrs_multi_version_build_deploy.yml
+++ b/.github/workflows/kdrs_multi_version_build_deploy.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           git fetch --all
           # get all branches, filter matching origin/x.y.z where xyz are integers, remove origin, sort by version, only get last which is most recent, remove space
-          echo latest_branch=$(git branch -r | grep -E 'origin/([0-9]+)\.([0-9]+)\.([0-9]+)$' | sed 's|origin/||' | sort -V | tail -n1 | tr -d '[:space:]') >> $GITHUB_ENV
+          echo latest_branch=$(git branch -r | grep -E 'origin/([0-9]+)\.([0-9]+)$' | sed 's|origin/||' | sort -V | tail -n1 | tr -d '[:space:]') >> $GITHUB_ENV
 
       # ---------------------------------------------------------
       # BUILD AND DEPLOY TO ROOT. This part only runs if the branch pushed to is the latest version.  

--- a/.github/workflows/kdrs_multi_version_build_deploy.yml
+++ b/.github/workflows/kdrs_multi_version_build_deploy.yml
@@ -72,22 +72,3 @@ jobs:
           clean: true # Automatically remove deleted files from the deploy branch
           clean-exclude: |
             !/version/${{github.ref_name}}
-
-
-            
-      
-    
-  # deploy:
-  #   permissions:
-  #     contents: read
-  #     pages: write
-  #     id-token: write
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   steps:
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v4

--- a/.github/workflows/kdrs_multi_version_build_deploy.yml
+++ b/.github/workflows/kdrs_multi_version_build_deploy.yml
@@ -2,7 +2,7 @@ name: Publish to GH Pages
 on:
   push:
     branches:
-      - '[0-9]*.[0-9]*.[0-9]*' # Match version names x.y.z. This is not regex supported so it would match 1ab.2bc.3asd, but not preview/1.2.3
+      - '[0-9]*.[0-9]*' # Match version names x*.y*. This is not regex supported so it would match 1ab.2bc.3asd, but not preview/1.2.3
 permissions:
   contents: write
 env:

--- a/.github/workflows/kdrs_multi_version_build_deploy.yml
+++ b/.github/workflows/kdrs_multi_version_build_deploy.yml
@@ -2,22 +2,23 @@ name: Publish to GH Pages
 on:
   push:
     branches:
-      - master
-  release:
-    types:
-      - published
+      - '[0-9]*.[0-9]*.[0-9]*' # Match version names x.y.z. This is not regex supported so it would match 1ab.2bc.3asd, but not preview/1.2.3
 permissions:
   contents: write
 env:
   kdrsInnsynDocVersionPath: /
   baseurl: /kdrs-search-and-view-docs/
+  latest_branch: x.y.z
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Update kdrsInnsynDocVersionPath for releases
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: echo kdrsInnsynDocVersionPath=/version/$(echo $GITHUB_REF | cut -d / -f 3 | cut -d v -f 2- | cut -d . -f 1,2) >> $GITHUB_ENV
+        # We only want the most recent version to be deployed to root, so find the most recent version
+      - name: Find most recent version
+        run: |
+          git fetch --all
+          # get all branches, filter matching origin/x.y.z where xyz are integers, remove origin, sort by version, only get last which is most recent, remove space
+          echo latest_branch=$(git branch -r | grep -E 'origin/([0-9]+)\.([0-9]+)\.([0-9]+)$' | sed 's|origin/||' | sort -V | tail -n1 | tr -d '[:space:]') >> $GITHUB_ENV
 
       # - name: Update kdrsInnsynDocVersionPath for non-main branches
       #   if: ${{ github.ref_type == 'branch' && github.ref_name != 'master'}}
@@ -40,15 +41,28 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 
-      - name: Deploy 🚀
+      - name: Deploy to versions
         uses: JamesIves/github-pages-deploy-action@v4.3.1
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: _site # The folder the action should deploy.
-          target-folder: ${{ env.kdrsInnsynDocVersionPath }}
+          target-folder: /version/${{github.ref_name}}
+          clean: true # Automatically remove deleted files from the deploy branch
+          clean-exclude: |
+            !/version/${{github.ref_name}}
+      
+      - name: Deploy to root if this is the most recent version
+        if: ${{ env.latest_branch == github.ref_name }} 
+        uses: JamesIves/github-pages-deploy-action@v4.3.1
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: _site # The folder the action should deploy.
+          target-folder: /
           clean: true # Automatically remove deleted files from the deploy branch
           clean-exclude: |
             version/*
+            
+      
     
   # deploy:
   #   permissions:

--- a/.github/workflows/kdrs_multi_version_build_deploy.yml
+++ b/.github/workflows/kdrs_multi_version_build_deploy.yml
@@ -32,10 +32,6 @@ jobs:
           source: ./
           destination: _site
 
-      - name: Upload artifact
-        if: ${{ env.latest_branch == github.ref_name }} 
-        uses: actions/upload-pages-artifact@v3
-
       - name: Deploy to root if this is the most recent version
         if: ${{ env.latest_branch == github.ref_name }} 
         uses: JamesIves/github-pages-deploy-action@v4.3.1
@@ -59,9 +55,6 @@ jobs:
         with:
           source: ./
           destination: _site
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
 
       - name: Deploy to versions
         uses: JamesIves/github-pages-deploy-action@v4.3.1

--- a/.github/workflows/kdrs_multi_version_build_deploy.yml
+++ b/.github/workflows/kdrs_multi_version_build_deploy.yml
@@ -13,6 +13,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
         # We only want the most recent version to be deployed to root, so find the most recent version
       - name: Find most recent version
         run: |
@@ -23,9 +26,6 @@ jobs:
       # - name: Update kdrsInnsynDocVersionPath for non-main branches
       #   if: ${{ github.ref_type == 'branch' && github.ref_name != 'master'}}
       #   run: echo kdrsInnsynDocVersionPath=/preview >> $GITHUB_ENV
-
-      - name: Checkout 🛎️
-        uses: actions/checkout@v4
 
       - name: Set baseurl # To make versions have hyperlinks relative to their directories, overwrite baseurl with version
         run: |

--- a/_includes/components/version_selector.html
+++ b/_includes/components/version_selector.html
@@ -85,7 +85,7 @@
     
     this.versionSelector.addEventListener("change", function(event) {
         this.selected = versionSelector.value;
-        const targetVersionPath = this.selected === 'latest' ? '' : `/version/${this.selected}`;
+        const targetVersionPath = this.selectedIndex == 0 ? '' : `/version/${this.selected}`;
         const path = window.location.pathname.toLowerCase();
         /* baseUrl might contain version number. If so, remove it. */
         let baseUrl = "{{site.baseurl}}"; 
@@ -96,7 +96,7 @@
         let baseUrlLength = baseUrl.length;
 
         let startIdx = baseUrlLength;
-        const versionIdx = path.indexOf('/version/');
+        const versionIdx = path.search(/\/version\/\d/);
         if (versionIdx >= 0) {
         startIdx = versionIdx + '/version/'.length;
         }

--- a/_includes/components/version_selector.html
+++ b/_includes/components/version_selector.html
@@ -4,7 +4,7 @@
 </span>
 <script>  
     const versionSelector = document.getElementById("versionSelector");
-    this.options = [{ value: "master", text: "master" }];
+    this.options = [{ value: "latest", text: "latest" }];
 
     (async function() {       
          await loadVersionsFromStorageOrGithub();
@@ -42,9 +42,7 @@
                         if (e1Arr[i] !== e2Arr[i]) return e2Arr[i] - e1Arr[i];
                     }
                     return e1.text === e2.text ? 0 : e2.text < e1.text ? -1 : 1;
-                    });
-                    versions.unshift({value: 'master', text: 'master'});
-                    
+                    });                    
                 } catch(ex) {
                     versions = this.options;
                 }
@@ -57,7 +55,7 @@
                 const end = path.indexOf('/', start);
                 this.selected = path.substring(start, end);
             } else {
-                this.selected = 'master';
+                this.selected = 'latest';
             }
         } catch (ex) {
             console.error(ex)
@@ -71,25 +69,23 @@
         return path.substring(versionEndIndex + 1, versionNumEndindex);
     }
     function buildVersionSelect() {
-        let indexCount = 0;
         let currentVersion = getCurrentVersion();
-        this.options.forEach(function(version) {
+        for(let i = 0; i < this.options.length; i++) {    
+            let version = this.options[i];    
             var option = document.createElement("option");
-
             option.value = version.value;
-            option.textContent = version.text == "master" ? "latest" : version.text;
+            option.textContent = i == 0 ? "latest (" + version.text + ")" : version.text;
             versionSelector.appendChild(option);
             if(option.value == currentVersion) {
-                versionSelector.selectedIndex = indexCount;
+                versionSelector.selectedIndex = i;
             }
-            indexCount++;
-        });
+        }
     }
     
     
     this.versionSelector.addEventListener("change", function(event) {
         this.selected = versionSelector.value;
-        const targetVersionPath = this.selected === 'master' ? '' : `/version/${this.selected}`;
+        const targetVersionPath = this.selected === 'latest' ? '' : `/version/${this.selected}`;
         const path = window.location.pathname.toLowerCase();
         /* baseUrl might contain version number. If so, remove it. */
         let baseUrl = "{{site.baseurl}}"; 


### PR DESCRIPTION
This change allows easier editing of old versions of documentation if necessary.

All branches with names following the pattern "x.y" will be built on push and stored in /version/x.y. They will be available from the version selector. If the branch name is the most recent version, it will also be deployed to root.